### PR TITLE
Alignment changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,8 +4,8 @@ Language:        Cpp
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Left
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false


### PR DESCRIPTION
* Declarations are not aligned anymore to prevent bad pointer alignment
* Escaped new lines are aligned to the right to minimize future changes

Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>